### PR TITLE
Fix issue #24 to add support for 0.37

### DIFF
--- a/app/src/main/java/com/elynx/pogoxmitm/Injector.java
+++ b/app/src/main/java/com/elynx/pogoxmitm/Injector.java
@@ -1,23 +1,32 @@
 package com.elynx.pogoxmitm;
 
+import android.net.Uri;
 import android.os.Build;
 
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
 import java.nio.ByteBuffer;
 
 import de.robv.android.xposed.IXposedHookLoadPackage;
 import de.robv.android.xposed.XC_MethodHook;
 import de.robv.android.xposed.XposedBridge;
+import de.robv.android.xposed.XposedHelpers;
 import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam;
 
 import static de.robv.android.xposed.XposedHelpers.findAndHookMethod;
+import static de.robv.android.xposed.XposedHelpers.findClass;
 
 /**
  * Class that manages injection of code into target app
  */
 public class Injector implements IXposedHookLoadPackage {
+    protected static boolean HasDoSyncRequest;
     protected static String[] Methods = {"GET", "HEAD", "POST", "PUT", "DELETE", "OPTIONS", "TRACE"};
 
     protected static ThreadLocal<RpcContext> rpcContext = new ThreadLocal<RpcContext>() {
@@ -38,6 +47,16 @@ public class Injector implements IXposedHookLoadPackage {
         }
 
         String NiaNetName = "com.nianticlabs.nia.network.NiaNet";
+        try {
+            XposedHelpers.findMethodExact(NiaNetName, lpparam.classLoader,
+                    //               0 object id 1 id       2 url         3 method   4 headers     5 buffer          6 offset   7 size
+                    "doSyncRequest", long.class, int.class, String.class, int.class, String.class, ByteBuffer.class, int.class, int.class);
+            HasDoSyncRequest = true;
+            XposedBridge.log("PoGo doSyncRequest found, 0.35 detected");
+        } catch (Throwable e) {
+            HasDoSyncRequest = false;
+            XposedBridge.log("PoGo doSyncRequest not found, 0.37+ detected");
+        }
 
         // real http class names are from
         // https://goshin.github.io/2016/07/14/Black-box-test-using-Xposed/
@@ -58,59 +77,61 @@ public class Injector implements IXposedHookLoadPackage {
         // note that joinHeaders and readDataSteam are called from doSyncRequest
 
         // method is executed in thread context
-        findAndHookMethod(NiaNetName, lpparam.classLoader,
-                //               0 object id 1 id       2 url         3 method   4 headers     5 buffer          6 offset   7 size
-                "doSyncRequest", long.class, int.class, String.class, int.class, String.class, ByteBuffer.class, int.class, int.class,
-                new XC_MethodHook() {
-                    @Override
-                    protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
-                        RpcContext context = rpcContext.get();
+        if(HasDoSyncRequest) {
+            findAndHookMethod(NiaNetName, lpparam.classLoader,
+                    //               0 object id 1 id       2 url         3 method   4 headers     5 buffer          6 offset   7 size
+                    "doSyncRequest", long.class, int.class, String.class, int.class, String.class, ByteBuffer.class, int.class, int.class,
+                    new XC_MethodHook() {
+                        @Override
+                        protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+                            RpcContext context = rpcContext.get();
 
-                        // fill in the context, this is threaded so each thread have individual
+                            // fill in the context, this is threaded so each thread have individual
 
-                        context.threadId = Thread.currentThread().getId();
-                        context.niaRequest = true;
+                            context.threadId = Thread.currentThread().getId();
+                            context.niaRequest = true;
 
-                        context.objectId = (long) param.args[0];
-                        context.requestId = (int) param.args[1];
-                        context.url = (String) param.args[2];
-                        context.method = Methods[(int) param.args[3]];
-                        context.requestHeaders = (String) param.args[4];
-                    }
+                            context.objectId = (long) param.args[0];
+                            context.requestId = (int) param.args[1];
+                            context.url = (String) param.args[2];
+                            context.method = Methods[(int) param.args[3]];
+                            context.requestHeaders = (String) param.args[4];
+                        }
 
-                    @Override
-                    protected void afterHookedMethod(MethodHookParam param) throws Throwable {
-                        // radical option
-                        // rpcContext.remove();
+                        @Override
+                        protected void afterHookedMethod(MethodHookParam param) throws Throwable {
+                            // radical option
+                            // rpcContext.remove();
 
-                        rpcContext.set(new RpcContext());
-                    }
-                });
+                            rpcContext.set(new RpcContext());
+                        }
+                    });
 
-        // method is executed in thread context
-        findAndHookMethod(NiaNetName, lpparam.classLoader,
-                "joinHeaders", HttpURLConnection.class,
-                new XC_MethodHook() {
-                    @Override
-                    protected void afterHookedMethod(MethodHookParam param) throws Throwable {
-                        RpcContext context = rpcContext.get();
+            // method is executed in thread context
+            findAndHookMethod(NiaNetName, lpparam.classLoader,
+                    "joinHeaders", HttpURLConnection.class,
+                    new XC_MethodHook() {
+                        @Override
+                        protected void afterHookedMethod(MethodHookParam param) throws Throwable {
+                            RpcContext context = rpcContext.get();
 
-                        context.responseHeaders = (String) param.getResult();
-                        context.responseCode = ((HttpURLConnection) param.args[0]).getResponseCode();
-                    }
-                });
+                            context.responseHeaders = (String) param.getResult();
+                            context.responseCode = ((HttpURLConnection) param.args[0]).getResponseCode();
+                        }
+                    });
 
-        // method is executed in thread context
-        findAndHookMethod(NiaNetName, lpparam.classLoader,
-                "readDataSteam", HttpURLConnection.class,
-                new XC_MethodHook() {
-                    @Override
-                    protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
-                        RpcContext context = rpcContext.get();
+            // method is executed in thread context
+            findAndHookMethod(NiaNetName, lpparam.classLoader,
+                    "readDataSteam", HttpURLConnection.class,
+                    new XC_MethodHook() {
+                        @Override
+                        protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+                            RpcContext context = rpcContext.get();
 
-                        context.niaResponse = true;
-                    }
-                });
+                            context.niaResponse = true;
+                        }
+                    });
+        }
 
         // method is executed in unknown context, make sure this is response for NiaNet
         findAndHookMethod(HttpURLConnectionImplName, lpparam.classLoader,
@@ -120,8 +141,9 @@ public class Injector implements IXposedHookLoadPackage {
                     protected void afterHookedMethod(MethodHookParam param) throws Throwable {
                         RpcContext context = rpcContext.get();
 
-                        if (!context.niaRequest)
+                        if (!context.niaRequest) {
                             return;
+                        }
 
                         XposedBridge.log("[request] " + context.shortDump());
 
@@ -130,6 +152,14 @@ public class Injector implements IXposedHookLoadPackage {
 
                         if (BuildConfig.DEBUG) {
                             XposedBridge.log("Output stream replaced");
+                        }
+                    }
+
+                    @Override
+                    protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+                        if (!HasDoSyncRequest) {
+                            // Request properties only available before method, headers not at all here
+                            rpcContext.set(RpcContext.fromConnection((URLConnection) param.thisObject, true));
                         }
                     }
                 });
@@ -152,6 +182,14 @@ public class Injector implements IXposedHookLoadPackage {
 
                         if (BuildConfig.DEBUG) {
                             XposedBridge.log("Input stream replaced");
+                        }
+                    }
+
+                    @Override
+                    protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+                        if (!HasDoSyncRequest) {
+                            // Request properties only available before method, headers not at all here
+                            rpcContext.set(RpcContext.fromConnection((URLConnection) param.thisObject, false));
                         }
                     }
                 });

--- a/app/src/main/java/com/elynx/pogoxmitm/RpcContext.java
+++ b/app/src/main/java/com/elynx/pogoxmitm/RpcContext.java
@@ -1,9 +1,19 @@
 package com.elynx.pogoxmitm;
 
+import java.net.HttpURLConnection;
+import java.net.URLConnection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import de.robv.android.xposed.XposedBridge;
+
 /**
  * Context of Rpc call in NiaNet
  */
 class RpcContext {
+    private static final String apiPrefix = "https://pgorelease.nianticlabs.com/plfe";
+    private static final String apiSuffix = "/rpc";
     long threadId = 0L;
     boolean niaRequest = false;
     boolean niaResponse = false;
@@ -15,6 +25,28 @@ class RpcContext {
     String requestHeaders;
     String responseHeaders;
     int responseCode = 0;
+
+    public static RpcContext fromConnection(URLConnection urlConnection, boolean isRequest) {
+        RpcContext rpcContext = new RpcContext();
+
+        try {
+            rpcContext.url = urlConnection.getURL().toExternalForm();
+            boolean isNia = rpcContext.url != null &&
+                    rpcContext.url.startsWith(apiPrefix) && rpcContext.url.endsWith(apiSuffix);
+            rpcContext.niaRequest = isRequest && isNia;
+            rpcContext.niaResponse = !isRequest && isNia;
+            rpcContext.threadId = Thread.currentThread().getId();
+
+            if (urlConnection instanceof HttpURLConnection) {
+                HttpURLConnection httpConnection = (HttpURLConnection) urlConnection;
+                rpcContext.method = httpConnection.getRequestMethod();
+            }
+        } catch (Throwable e) {
+            XposedBridge.log(e);
+        }
+
+        return rpcContext;
+    }
 
     public String shortDump() {
         return Integer.toString(requestId) + " " + method + " " + url;


### PR DESCRIPTION
Fix issue #24 to add support for 0.37.

When doSyncRequest does not exist, detect PoGo request data from getInputStream and getOutputStream instead and pass using existing logic for MITM.

Given changes to SafetyNet today, the only way to use is SuperSU systemless with [suhide](http://forum.xda-developers.com/apps/supersu/suhide-t3450396) and specific Xposed framework version.  This is backwards compatible with 0.35.
